### PR TITLE
[dev] storing analysis results in datastore

### DIFF
--- a/src/main/java/highfives/Constants.java
+++ b/src/main/java/highfives/Constants.java
@@ -1,11 +1,20 @@
 package highfives;
 
+
 //Class to store constants
 public final class Constants {
 
-    // Parameter for /analyze/text
     public static final String ANALYZE_TEXT = "text";
 
-    // Maximum length of text to be processed
     public static final Integer TEXT_MAX_LENGTH = 10000;
+
+    public static final String _ANALYSIS = "Analysis";
+
+    public static final String SENTIMENT = "score";
+
+    public static final String ENTITY_SENTIMENTS = "entities";
+
+    public static final String WORD_FREQUENCIES = "wordcount";
+
+    public static final String RESULT = "result";
 }

--- a/src/main/java/highfives/data/AnalysisResult.java
+++ b/src/main/java/highfives/data/AnalysisResult.java
@@ -1,0 +1,28 @@
+package highfives.data;
+
+import org.json.JSONObject;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import highfives.Constants;
+
+
+/** Analysis result for a certain text */
+@AllArgsConstructor
+public final class AnalysisResult {
+    private final long id;
+    @Getter private final String text;
+    @Getter private final String result;
+
+    public AnalysisResult(long id, String text, float sentiment, JSONObject entitySentiments, JSONObject wordFrequencies) {
+        this.id = id;
+        this.text = text;
+
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put(Constants.SENTIMENT, sentiment);
+        jsonObject.put(Constants.ENTITY_SENTIMENTS, entitySentiments);
+        jsonObject.put(Constants.WORD_FREQUENCIES, wordFrequencies);
+        this.result = jsonObject.toString();
+    }
+}

--- a/src/main/java/highfives/utils/DatastoreUtils.java
+++ b/src/main/java/highfives/utils/DatastoreUtils.java
@@ -1,0 +1,67 @@
+package highfives.utils;
+
+import java.util.List;
+import org.json.JSONObject;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.Query.SortDirection;
+import com.google.appengine.api.datastore.KeyFactory;
+import com.google.appengine.api.datastore.Key;
+
+import highfives.data.AnalysisResult;
+import highfives.Constants;
+
+
+// Class to perform operations on datastore
+public final class DatastoreUtils {
+
+    // Get analysis of a text from datastore
+    // return null if not found
+    public static AnalysisResult getAnalysis(String text)
+    {    
+        try {
+    
+            // Find analysis with the given text
+            Query query = new Query(Constants._ANALYSIS);
+            query.addFilter(Constants.ANALYZE_TEXT, Query.FilterOperator.EQUAL, text);
+
+            //Get analysis from datastore
+            DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+            PreparedQuery results = datastore.prepare(query);
+
+            AnalysisResult analysis = null;
+            for (Entity entity : results.asIterable()) {
+                long id = entity.getKey().getId();
+                analysis = new AnalysisResult(id, text, (String) entity.getProperty(Constants.RESULT));
+            }
+    
+            return analysis;
+
+        } catch (Exception e) {
+            return null;
+        }        
+    }
+
+    // Save analysis for the given text
+    public static AnalysisResult saveAnalysis(String text, float sentiment, JSONObject entitySentiments, JSONObject wordFrequencies)
+    {
+        // Construct Analysis object from data
+        AnalysisResult analysis = new AnalysisResult(0, text, sentiment, entitySentiments, wordFrequencies);
+
+        // Upload data to datastore
+        Entity analysisEntity = new Entity(Constants._ANALYSIS);
+        analysisEntity.setProperty(Constants.ANALYZE_TEXT, text);
+        analysisEntity.setProperty(Constants.RESULT, analysis.getResult());
+
+        try {
+            DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+            datastore.put(analysisEntity);
+        } catch (Exception e) {}
+
+        return analysis;
+    }
+}

--- a/src/main/java/highfives/utils/NaturalLanguageAPIUtils.java
+++ b/src/main/java/highfives/utils/NaturalLanguageAPIUtils.java
@@ -1,5 +1,8 @@
 package highfives.utils;
 
+import java.util.List;
+import java.util.Map;
+
 import com.google.cloud.language.v1.AnalyzeEntitiesRequest;
 import com.google.cloud.language.v1.AnalyzeEntitiesResponse;
 import com.google.cloud.language.v1.AnalyzeEntitySentimentRequest;
@@ -13,8 +16,6 @@ import com.google.cloud.language.v1.EntityMention;
 import com.google.cloud.language.v1.LanguageServiceClient;
 import com.google.cloud.language.v1.Sentiment;
 import com.google.cloud.language.v1.Token;
-import java.util.List;
-import java.util.Map;
 
 
 // Class containing functions that make Natural Language API calls

--- a/src/main/webapp/js/displayResult.js
+++ b/src/main/webapp/js/displayResult.js
@@ -6,35 +6,6 @@ $(document).ready(function () {
 //on form input
 $('#input-text-form').submit(function (e) {
   e.preventDefault();
-  
-	//get inputs
-	var inputType = document.getElementById("input-text-options");
-	var inputText = document.getElementById("input-text");
-
-
-	//input type text
-	var textObject = {
-		"text": inputText.value
-	}
-
-
-	$.ajax({
-		url: "/analyze/text",
-		type: 'POST',
-		dataType: 'json',
-		data: JSON.stringify(textObject),
-		contentType: 'application/json',
-		mimeType: 'application/json',
-
-		success: function (response) {
-   
-            setScore(response);
-     
-		},
-		error: function (data, status, er) {
-			alert("error: " + " status: " + status + " er:" + er);
-		}
-	});
 
   //get inputs
   var inputType = $('#input-text-options').val();


### PR DESCRIPTION
The `/analyze/text` now first checks whether the text exists in cloud datastore. If yes, it returns the analysis result from there, else, it makes an NL API call, stores the result in datastore and then returns it.

## Notable Changes

- Added `AnalysisResult.java`, a data class to store analysis' results.
- Added `DatastoreUtils.java`, to interact with datastore (add or retrieve analysis).
- Changed `/analyze/text` (`AnalyzeTextServlet.java`) to check datastore, and save to it, using `DatastoreUtils`.
