### PR TITLE
[dev] Request text null bug fix

### DIFF
--- a/src/main/java/highfives/servlets/AnalyzeTextServlet.java
+++ b/src/main/java/highfives/servlets/AnalyzeTextServlet.java
@@ -3,6 +3,7 @@ package highfives.servlets;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.json.JSONObject;
 
 import javax.servlet.annotation.WebServlet;
@@ -24,7 +25,9 @@ public class AnalyzeTextServlet extends HttpServlet {
     public void doPost(HttpServletRequest request, HttpServletResponse response)
         throws IOException {
 
-        String text = request.getParameter(Constants.ANALYZE_TEXT);
+        // Get POST request body as JSON
+        JSONObject requestBody = new JSONObject(request.getReader().lines().collect(Collectors.joining()));
+        String text = (String) requestBody.get(Constants.ANALYZE_TEXT);
 
         // If length of the text exceeds the limit, send bad request (400)
         if(text.length() > Constants.TEXT_MAX_LENGTH) {

--- a/src/main/webapp/js/displayResult.js
+++ b/src/main/webapp/js/displayResult.js
@@ -26,13 +26,13 @@ $('#input-text-form').submit(function (e) {
 		url: "/analyze/text",
 		type: 'POST',
 		dataType: 'json',
-		data: textObject,
+		data: JSON.stringify(textObject),
 		contentType: 'application/json',
 		mimeType: 'application/json',
 
 		success: function (response) {
    
-      setScore(response);
+            setScore(response);
      
 		},
 		error: function (data, status, er) {


### PR DESCRIPTION
Fixed an issue that caused the `text` parameter to be null.

The issue happened because `getParameter` only works on a url-encoded request, and the body of the request wasn't stringified while being sent.